### PR TITLE
Se modifica PublicationController en como recibe la category

### DIFF
--- a/src/controller/publications/PublicationController.ts
+++ b/src/controller/publications/PublicationController.ts
@@ -266,7 +266,7 @@ export class PublicationController {
         initialContent,
         finalContent,
         finalContent_EN: finalContent_en,
-        category: category[0] || null,
+        category,
         location,
         published: published ? JSON.parse(published) : undefined,
         fecha_publicacion: new Date(fecha_publicacion),


### PR DESCRIPTION
Se modifico en PublicationController el como espera el request para unificar  la solicitud para el POST y el PUT en category.
Esto va de la mano con la modificacion del front que ya no permite multiples selecciones sino solo una siguiendo las definiciones de las relaciones.